### PR TITLE
Added support for double-quote enclosed params

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -304,6 +304,8 @@ pub trait AbstractInput<'a, I>:
     + nom::InputLength
     + nom::InputIter
     + nom::Compare<&'a str>
+    + nom::Offset
+    + nom::Slice<core::ops::RangeTo<usize>>
     + std::fmt::Debug
     + Into<&'a bstr::BStr>
     + Default

--- a/tests/headers/tokenizers/display_uri_params.rs
+++ b/tests/headers/tokenizers/display_uri_params.rs
@@ -78,3 +78,30 @@ fn tokenizer4() {
         })
     );
 }
+
+// Used "+sip.instance" Contact param as an example for double-quote-enclosed param value
+// for +sip.instance specification, see RFC 5626.
+#[test]
+fn tokenizer_with_instance() {
+    assert_eq!(
+        DisplayUriParamsTokenizer::tokenize(
+            r#"<sip:alice@atlanta.example.com>;+sip.instance="<urn:uuid:9e397c26-8f87-4b02-9df1-987ddfe135c3>""#
+        ),
+        Ok(DisplayUriParamsTokenizer {
+            display_name: None,
+            uri: uri::Tokenizer {
+                scheme: Some("sip".into()),
+                auth: Some(uri::auth::Tokenizer::from(("alice", None,))),
+                host_with_port: ("atlanta.example.com", None).into(),
+                params: vec![],
+                headers: None,
+                ..Default::default()
+            },
+            params: vec![(
+                "+sip.instance",
+                Some(r#""<urn:uuid:9e397c26-8f87-4b02-9df1-987ddfe135c3>""#)
+            )
+                .into()],
+        })
+    );
+}


### PR DESCRIPTION
While using this library for SIP communication I discovered it doesn't support double-quoted params in headers.
Example of such parameter can be found in [RFC 5626](https://www.rfc-editor.org/rfc/rfc5626): the field `+sip.instance` is always enclosed in double-quotes.
This is my proposal of adding a possibility to parse such fields.