### PR TITLE
Adding support for `tel` scheme

### DIFF
--- a/src/common/uri/scheme.rs
+++ b/src/common/uri/scheme.rs
@@ -9,6 +9,8 @@ use crate::Error;
 pub enum Scheme {
     Sip,
     Sips,
+    // A tel scheme from RFC 2806.
+    Tel,
     Other(String),
 }
 
@@ -43,6 +45,7 @@ impl std::fmt::Display for Scheme {
         match self {
             Self::Sip => write!(f, "sip"),
             Self::Sips => write!(f, "sips"),
+            Self::Tel => write!(f, "tel"),
             Self::Other(inner) => write!(f, "{}", inner),
         }
     }
@@ -55,6 +58,7 @@ impl<'a> std::convert::TryFrom<tokenizer::Tokenizer<'a, &'a str, char>> for Sche
         match tokenizer.value {
             part if part.eq_ignore_ascii_case("sip") => Ok(Scheme::Sip),
             part if part.eq_ignore_ascii_case("sips") => Ok(Scheme::Sips),
+            part if part.eq_ignore_ascii_case("tel") => Ok(Scheme::Tel),
             part => Ok(Scheme::Other(part.into())),
         }
     }
@@ -115,6 +119,7 @@ pub mod tokenizer {
             let (rem, (scheme, _)) = alt((
                 tuple((tag_no_case("sip"), tag(":"))),
                 tuple((tag_no_case("sips"), tag(":"))),
+                tuple((tag_no_case("tel"), tag(":"))),
                 tuple((take_until("://"), tag("://"))),
             ))(part)
             .map_err(|_: GenericNomError<'a, T>| TokenizerError::from(("scheme", part)).into())?;

--- a/tests/common/uri/scheme.rs
+++ b/tests/common/uri/scheme.rs
@@ -33,6 +33,14 @@ mod parser {
             Ok(Scheme::Sips)
         );
     }
+
+    #[test]
+    fn parser3() {
+        assert_eq!(
+            Tokenizer::from("tel".as_bytes()).try_into(),
+            Ok(Scheme::Tel)
+        )
+    }
 }
 
 mod tokenizer {
@@ -66,6 +74,14 @@ mod tokenizer {
                 "sips".as_bytes().into()
             )),
         );
+    }
+
+    #[test]
+    fn tokenizer3_str() {
+        assert_eq!(
+            Tokenizer::tokenize("tel:+12124567890"),
+            Ok(("+12124567890", "tel".into())),
+        )
     }
 
     #[test]

--- a/tests/common/uri/uri_with_params.rs
+++ b/tests/common/uri/uri_with_params.rs
@@ -1,6 +1,6 @@
 use rsip::common::uri::{
     self,
-    param::{Maddr, Param},
+    param::{Maddr, Param, Tag},
     uri_with_params::{Tokenizer, UriWithParams},
     Scheme, Uri,
 };
@@ -49,6 +49,25 @@ mod display {
             .to_string(),
             String::from("<sips:client.biloxi.example.com:5061;s=2>")
         );
+    }
+
+    #[test]
+    fn display3() {
+        let tag = Tag::default();
+        assert_eq!(
+            UriWithParams {
+                uri: Uri {
+                    scheme: Some(Scheme::Tel),
+                    auth: None,
+                    host_with_port: "+12124567890".try_into().unwrap(),
+                    params: Default::default(),
+                    headers: Default::default()
+                },
+                params: vec![Param::Tag(tag.clone())],
+            }
+            .to_string(),
+            format!("<tel:+12124567890>;tag={}", tag)
+        )
     }
 }
 
@@ -239,6 +258,30 @@ mod tokenizer {
                     ..Default::default()
                 }
             )),
+        );
+    }
+
+    #[test]
+    fn tokenizer3_str() {
+        let tag: String = Tag::default().into();
+        let input = format!("<tel:+12124567890>;tag={}", tag);
+        assert_eq!(
+            Tokenizer::tokenize(input.as_str()),
+            Ok((
+                "",
+                Tokenizer {
+                    uri: uri::Tokenizer {
+                        scheme: Some("tel".into()),
+                        auth: None,
+                        host_with_port: ("+12124567890", None).into(),
+                        params: vec![],
+                        headers: None,
+                        ..Default::default()
+                    },
+                    params: vec![("tag", Some(tag.as_str())).into()],
+                    ..Default::default()
+                }
+            ))
         );
     }
 }


### PR DESCRIPTION
Adding support for `tel` scheme from [RFC 2806](https://www.rfc-editor.org/rfc/rfc2806).

Just adds recognition scheme name itself without validation of a number itself. I didn't seen it necessary as this repo would probably be replace with public release of internal version as mentioned in [PR#39](https://github.com/Televiska/rsip/pull/39#issuecomment-1217652486).

I'm aware that this is technically a breaking change (modifies public enum), but I don't really see better way to make tel URI parse as colon is also used for `user:password` syntax.